### PR TITLE
Bump to 1.15.1-1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "1.15.1" %}
-{% set release = "0" %}
-{% set sha256 = "95d223a5af156eade11396b6e4bce23141d0dafb601099188ec163c83d862a4e" %}
+{% set release = "1" %}
+{% set sha256 = "e18754d4e2c9cd385c26b84b232f602021083147e3b93d6e35ce9071e943e81f" %}
 {% set so = "3" %}
 
 package:


### PR DESCRIPTION
https://github.com/TileDB-Inc/m2w64-htslib-build/releases/tag/1.15.1-1

Includes the 2 patches added in https://github.com/TileDB-Inc/m2w64-htslib-build/pull/2

**Note:** For initial convenience, I tightly coupled the "release" number of our msys2 htslib build with the "build" number of the conda recipe. If we find ourselves having to regularly update the conda recipe but not the release tarball itself, then I'll uncouple for them