### PR TITLE
Build htslib 1.19

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set version = "1.16" %}
+{% set version = "1.19" %}
 {% set release = "0" %}
-{% set sha256 = "ac6a03e561eba22b9de0fd93e6b3d5aea0c72a5981e6a8157a24c8799bd3a8aa" %}
+{% set sha256 = "3e745a32ba0c17e2e63e16deab51af7ce1dd6ddc8fbc850811031a7c3406e7ee" %}
 {% set so = "3" %}
 
 package:


### PR DESCRIPTION
xref: https://github.com/TileDB-Inc/m2w64-htslib-feedstock/pull/7, https://github.com/TileDB-Inc/m2w64-htslib-build/pull/7, and https://github.com/TileDB-Inc/m2w64-htslib-build/releases/tag/1.19-0

```sh
wget https://github.com/TileDB-Inc/m2w64-htslib-build/releases/download/1.19-0/m2w64-htslib-1.19-0.tar.gz
openssl sha256 m2w64-htslib-1.19-0.tar.gz
## SHA2-256(m2w64-htslib-1.19-0.tar.gz)= 3e745a32ba0c17e2e63e16deab51af7ce1dd6ddc8fbc850811031a7c3406e7ee
```